### PR TITLE
おそらくsessionモデルを作ってしまったがためにdeviseの既存ディレクトリとバッティングしたと思われる

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root to:"sounds#index"
   devise_for :users
+  devise_scope :user do
+    match '/sessions/user', to: 'devise/sessions#create', via: :post
+  end
 
   resources :sounds do
    member do


### PR DESCRIPTION
以下の記述をroutes.rbに追記して改善した
↓
devise_scope :user do
  match '/sessions/user', to: 'devise/sessions#create', via: :post
end